### PR TITLE
Add alg field to JWKS PublicKeyResponse deserialization

### DIFF
--- a/media-service-api/dialog-connector-simulator/src/main/java/com/cisco/wccai/grpc/server/interceptors/JWTAuthorizationHandler.java
+++ b/media-service-api/dialog-connector-simulator/src/main/java/com/cisco/wccai/grpc/server/interceptors/JWTAuthorizationHandler.java
@@ -132,8 +132,15 @@ public class JWTAuthorizationHandler implements AuthorizationHandler {
 
     private boolean validateJWT(String jwtString, String jwkString) throws JOSEException, ParseException {
         JWK jwk = JWK.parse(jwkString);
-        RSAPublicKey publicKey = (RSAPublicKey) jwk.toRSAKey().toPublicKey();
         SignedJWT signedJWT = SignedJWT.parse(jwtString);
+
+        if (jwk.getAlgorithm() != null && !jwk.getAlgorithm().equals(signedJWT.getHeader().getAlgorithm())) {
+            LOGGER.warn("Algorithm mismatch - JWT header: {}, JWKS key: {}",
+                    signedJWT.getHeader().getAlgorithm(), jwk.getAlgorithm());
+            return false;
+        }
+
+        RSAPublicKey publicKey = (RSAPublicKey) jwk.toRSAKey().toPublicKey();
         JWSVerifier verifier = new RSASSAVerifier(publicKey);
         boolean verified = signedJWT.verify(verifier);
         if (verified) {

--- a/media-service-api/dialog-connector-simulator/src/main/java/com/cisco/wccai/grpc/server/interceptors/PublicKeyResponse.java
+++ b/media-service-api/dialog-connector-simulator/src/main/java/com/cisco/wccai/grpc/server/interceptors/PublicKeyResponse.java
@@ -1,5 +1,6 @@
 package com.cisco.wccai.grpc.server.interceptors;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Getter
 @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PublicKeyResponse {
 
     @JsonProperty("keys")
@@ -32,6 +34,9 @@ public class PublicKeyResponse {
         @JsonProperty("n")
         private String n;
 
+        @JsonProperty("alg")
+        private String alg;
+
         @Override
         public String toString() {
             return "{" +
@@ -39,7 +44,8 @@ public class PublicKeyResponse {
                     "\"e\":\"" + e + "\"," +
                     "\"use\":\"" + use + "\"," +
                     "\"kid\":\"" + kid + "\"," +
-                    "\"n\":\"" + n + "\"" +
+                    "\"n\":\"" + n + "\"," +
+                    "\"alg\":\"" + alg + "\"" +
                     "}";
         }
     }

--- a/media-service-api/dialog-connector-simulator/src/main/java/com/cisco/wccai/grpc/server/interceptors/PublicKeyResponse.java
+++ b/media-service-api/dialog-connector-simulator/src/main/java/com/cisco/wccai/grpc/server/interceptors/PublicKeyResponse.java
@@ -44,8 +44,8 @@ public class PublicKeyResponse {
                     "\"e\":\"" + e + "\"," +
                     "\"use\":\"" + use + "\"," +
                     "\"kid\":\"" + kid + "\"," +
-                    "\"n\":\"" + n + "\"," +
-                    "\"alg\":\"" + alg + "\"" +
+                    "\"n\":\"" + n + "\"" +
+                    (alg != null ? ",\"alg\":\"" + alg + "\"" : "") +
                     "}";
         }
     }


### PR DESCRIPTION
Cisco's JWKS endpoint now returns an alg field. This was causing UnrecognizedPropertyException during public key fetch, breaking token validation. Added the alg field and @JsonIgnoreProperties(ignoreUnknown = true) as a safeguard for any future field additions. (CCCAI-8887)